### PR TITLE
feat: implement RAII guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The code:
 use thread_amount::thread_amount;
 
 use std::thread;
+use std::num::NonZeroUsize;
 
 fn main() {
     let amount = thread_amount();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![warn(clippy::pedantic)]
 
 use std::num::NonZeroUsize;

--- a/src/osx.rs
+++ b/src/osx.rs
@@ -1,31 +1,59 @@
 use std::num::NonZeroUsize;
-use std::{mem, ptr};
 
 use mach2::kern_return::KERN_SUCCESS;
 use mach2::mach_types::thread_act_array_t;
 use mach2::message::mach_msg_type_number_t;
-use mach2::port::mach_port_t;
+use mach2::port::{mach_port_deallocate, mach_port_t};
 use mach2::task::task_threads;
 use mach2::traps::mach_task_self;
 use mach2::vm::mach_vm_deallocate;
 use mach2::vm_types::{mach_vm_address_t, mach_vm_size_t};
 
-pub(crate) fn thread_amount() -> Option<NonZeroUsize> {
-    unsafe {
-        let task = mach_task_self();
-        let mut thread_list: thread_act_array_t = ptr::null_mut();
-        let mut count: mach_msg_type_number_t = 0;
-        let rc = task_threads(task, &mut thread_list, &mut count);
+struct MachThreadList {
+    threads: thread_act_array_t,
+    count: mach_msg_type_number_t,
+}
 
-        if rc != KERN_SUCCESS {
+impl Drop for MachThreadList {
+    fn drop(&mut self) {
+        if self.threads.is_null() || self.count == 0 {
+            return;
+        }
+
+        unsafe {
+            let threads_slice = std::slice::from_raw_parts(self.threads, self.count as usize);
+            for &thread_port in threads_slice {
+                mach_port_deallocate(mach_task_self(), thread_port);
+            }
+
+            let size = (self.count as usize) * std::mem::size_of::<mach_port_t>();
+
+            mach_vm_deallocate(
+                mach_task_self(),
+                self.threads as mach2::vm_types::mach_vm_address_t,
+                size as mach2::vm_types::mach_vm_size_t,
+            );
+        }
+    }
+}
+
+pub(crate) fn thread_amount() -> Option<NonZeroUsize> {
+    let mut thread_list: thread_act_array_t = std::ptr::null_mut();
+    let mut thread_count: mach_msg_type_number_t = 0;
+
+    unsafe {
+        let result = task_threads(mach_task_self(), &mut thread_list, &mut thread_count);
+
+        if result != KERN_SUCCESS {
             return None;
         }
 
-        let result = NonZeroUsize::new(count as usize);
-        let size = (count as usize * mem::size_of::<mach_port_t>()) as mach_vm_size_t;
-        let _ = mach_vm_deallocate(task, thread_list as mach_vm_address_t, size);
+        let _guard = MachThreadList {
+            threads: thread_list,
+            count: thread_count,
+        };
 
-        result
+        NonZeroUsize::new(thread_count as usize)
     }
 }
 

--- a/src/osx.rs
+++ b/src/osx.rs
@@ -1,9 +1,10 @@
 use std::num::NonZeroUsize;
 
 use mach2::kern_return::KERN_SUCCESS;
+use mach2::mach_port::mach_port_deallocate;
 use mach2::mach_types::thread_act_array_t;
 use mach2::message::mach_msg_type_number_t;
-use mach2::port::{mach_port_deallocate, mach_port_t};
+use mach2::port::mach_port_t;
 use mach2::task::task_threads;
 use mach2::traps::mach_task_self;
 use mach2::vm::mach_vm_deallocate;
@@ -30,8 +31,8 @@ impl Drop for MachThreadList {
 
             mach_vm_deallocate(
                 mach_task_self(),
-                self.threads as mach2::vm_types::mach_vm_address_t,
-                size as mach2::vm_types::mach_vm_size_t,
+                self.threads as mach_vm_address_t,
+                size as mach_vm_size_t,
             );
         }
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use std::num::NonZeroUsize;
 
-use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot,
     TH32CS_SNAPTHREAD,
@@ -11,33 +11,46 @@ use windows_sys::Win32::System::Diagnostics::ToolHelp::{
 };
 use windows_sys::Win32::System::Threading::GetCurrentProcessId;
 
+struct SnapshotHandle(HANDLE);
+
+impl Drop for SnapshotHandle {
+    fn drop(&mut self) {
+        if self.0 != INVALID_HANDLE_VALUE && self.0 != 0 {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+}
+
 pub(crate) fn thread_amount() -> Option<NonZeroUsize> {
     unsafe {
-        let pid = GetCurrentProcessId();
         let handle = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
-
-        if handle == INVALID_HANDLE_VALUE {
+        if handle == INVALID_HANDLE_VALUE || handle == 0 {
             return None;
         }
 
-        let mut count = 0;
+        let guard = SnapshotHandle(handle);
 
-        let mut te: THREADENTRY32 = mem::zeroed();
-        te.dwSize = mem::size_of::<THREADENTRY32>() as u32;
+        let mut te32: THREADENTRY32 = std::mem::zeroed();
+        te32.dwSize = std::mem::size_of::<THREADENTRY32>() as u32;
 
-        if Thread32First(handle, &mut te) != 0 {
-            loop {
-                if te.th32OwnerProcessID == pid {
-                    count += 1;
-                }
-
-                if Thread32Next(handle, &mut te) == 0 {
-                    break;
-                }
-            }
+        if Thread32First(guard.0, &mut te32) == 0 {
+            return None;
         }
 
-        CloseHandle(handle);
+        let pid = GetCurrentProcessId();
+        let mut count = 0;
+
+        loop {
+            if te32.th32OwnerProcessID == pid {
+                count += 1;
+            }
+
+            if Thread32Next(guard.0, &mut te32) == 0 {
+                break;
+            }
+        }
 
         NonZeroUsize::new(count)
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use std::num::NonZeroUsize;
 
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -14,7 +14,7 @@ struct SnapshotHandle(HANDLE);
 
 impl Drop for SnapshotHandle {
     fn drop(&mut self) {
-        if self.0 != INVALID_HANDLE_VALUE && self.0 != 0 {
+        if self.0 != INVALID_HANDLE_VALUE && !self.0.is_null() {
             unsafe {
                 CloseHandle(self.0);
             }
@@ -25,7 +25,7 @@ impl Drop for SnapshotHandle {
 pub(crate) fn thread_amount() -> Option<NonZeroUsize> {
     unsafe {
         let handle = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
-        if handle == INVALID_HANDLE_VALUE || handle == 0 {
+        if handle == INVALID_HANDLE_VALUE || handle.is_null() {
             return None;
         }
 


### PR DESCRIPTION
We encapsulate OS-level pointers and handles into safe structs and implementing the `Drop` trait. This guarantees that whether the function finishes successfully, encounters an early return, or panics, the OS resources (Windows Handles and Mach memory/ports) are automatically freed when the guard goes out of scope.